### PR TITLE
Properly support constraints expressed by bean validation (jsr303) annotations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,9 @@
     <!-- Zeichensatz -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Verwendete Versionen -->
-    <hibernate-core.version>4.3.0.Final</hibernate-core.version>
-    <hibernate-envers.version>4.3.0.Final</hibernate-envers.version>
+    <hibernate-core.version>4.3.1.Final</hibernate-core.version>
+    <hibernate-envers.version>4.3.1.Final</hibernate-envers.version>
+    <hibernate-validator.version>4.3.1.Final</hibernate-validator.version>
     <maven.version>3.0.4</maven.version>
     <maven-plugin-log4j.version>1.0.1</maven-plugin-log4j.version>
     <scannotation.version>1.0.3</scannotation.version>
@@ -146,7 +147,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>4.3.1.Final</version>
+      <version>${hibernate-validator.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scannotation</groupId>

--- a/src/main/java/de/juplo/plugins/hibernate4/Hbm2DdlMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate4/Hbm2DdlMojo.java
@@ -670,15 +670,7 @@ public class Hbm2DdlMojo extends AbstractMojo
       throw new MojoFailureException("Hibernate configuration is missing!");
     }
 
-    Configuration config= null;
-    try
-    {
-      config = new ValidationConfiguration(hibernateDialect);
-    }
-    catch (ClassNotFoundException e)
-    {
-      e.printStackTrace();
-    }
+    final Configuration config = new ValidationConfiguration(hibernateDialect);
 
     config.setProperties(properties);
 

--- a/src/main/java/org/hibernate/cfg/beanvalidation/TypeSafeActivatorAccessor.java
+++ b/src/main/java/org/hibernate/cfg/beanvalidation/TypeSafeActivatorAccessor.java
@@ -1,0 +1,11 @@
+package org.hibernate.cfg.beanvalidation;
+
+/**
+ * This class enables access to the public methods of {@link TypeSafeActivator}
+ * which itself is visible in the package only.
+ *
+ * @author Frank Schimmel <frank.schimmel@cm4all.com>
+ */
+public class TypeSafeActivatorAccessor extends TypeSafeActivator {
+    // Empty: just makes public methods accessible.
+}


### PR DESCRIPTION
- Access public method of package-visible TypeSafeActivator class without reflection.
- Fix arguments to call of TypeSafeActivator.applyRelationalConstraints() (1st arg was missing).
- Use hibernate version 4.3.1.Final for all components.
- Minor refactorings in exception handling.
