### PR TITLE
Add queries extraction file (HQL and native queries)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>hibernate-maven-plugin</artifactId>
   <name>Hibernate Maven Plugin</name>
   <description>Plugin for generating a database-schema from Hibernate-Mapping-Annotations</description>
-  <version>2.0.1.IFR</version>
+  <version>2.0.2.IFR-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <url>http://juplo.de/hibernate-maven-plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>hibernate-maven-plugin</artifactId>
   <name>Hibernate Maven Plugin</name>
   <description>Plugin for generating a database-schema from Hibernate-Mapping-Annotations</description>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <url>http://juplo.de/hibernate-maven-plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <!-- Zeichensatz -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Verwendete Versionen -->
-    <hibernate.version>5.0.2.Final</hibernate.version>
+    <hibernate.version>5.0.6.Final</hibernate.version>
     <hibernate-validator.version>5.2.2.Final</hibernate-validator.version>
     <el-api.version>3.0.0</el-api.version>
     <maven.version>3.3.3</maven.version>
@@ -168,6 +168,11 @@
       <version>${hibernate-validator.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>javax.el</groupId>
       <artifactId>javax.el-api</artifactId>
       <version>${el-api.version}</version>
@@ -177,6 +182,7 @@
       <artifactId>scannotation</artifactId>
       <version>${scannotation.version}</version>
     </dependency>
+
     <dependency>
       <groupId>com.pyx4j</groupId>
       <artifactId>maven-plugin-log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>hibernate-maven-plugin</artifactId>
   <name>Hibernate Maven Plugin</name>
   <description>Plugin for generating a database-schema from Hibernate-Mapping-Annotations</description>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1.IFR</version>
   <packaging>maven-plugin</packaging>
   <url>http://juplo.de/hibernate-maven-plugin</url>
 
@@ -133,6 +133,7 @@
     <maven.version>3.3.3</maven.version>
     <maven-plugin-log4j.version>1.0.1</maven-plugin-log4j.version>
     <scannotation.version>1.0.4</scannotation.version>
+    <freemarker.version>2.3.23</freemarker.version>
   </properties>
 
   <dependencies>
@@ -181,6 +182,11 @@
       <groupId>de.juplo</groupId>
       <artifactId>scannotation</artifactId>
       <version>${scannotation.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>${freemarker.version}</version>
     </dependency>
 
     <dependency>

--- a/src/it/tutorials/extract-queries.sql
+++ b/src/it/tutorials/extract-queries.sql
@@ -1,0 +1,61 @@
+--
+-- Queries extraction file
+--
+-- ************************************************************
+-- Get event by id.
+-- Useful when loading event details
+--
+-- @name			eventById
+-- @param			eventId		java.lang.Integer
+--
+-- @hql
+--   SELECT
+--   		  e.id
+--   		FROM
+--   		  org.hibernate.tutorial.hbm.Event e
+--   		WHERE e.id = :eventId
+--
+-- ************************************************************
+
+    select
+        event0_.EVENT_ID as col_0_0_ 
+    from
+        EVENTS event0_ 
+    where
+        event0_.EVENT_ID=?;
+
+
+-- ************************************************************
+-- Delete an event
+--
+-- @name			deleteEvent
+-- @param			eventId		java.lang.Integer
+--
+-- @hql
+--   DELETE FROM
+--   		  org.hibernate.tutorial.hbm.Event e
+--   		WHERE e.id = :eventId
+--
+-- ************************************************************
+
+    delete 
+    from
+        EVENTS 
+    where
+        EVENT_ID=?;
+
+
+-- ************************************************************
+-- A native query to get event by id
+--
+-- @name			nativeEventById
+-- @param			eventId		java.lang.Integer
+--
+-- ************************************************************
+
+    select
+        EVENT_ID             
+    from
+        EVENTS             
+    where
+        EVENT_ID=:eventId;

--- a/src/it/tutorials/pom.xml
+++ b/src/it/tutorials/pom.xml
@@ -47,6 +47,7 @@
         <module>osgi/unmanaged-native</module>
         <module>osgi/unmanaged-jpa</module>
         <module>osgi/managed-jpa</module>
+        <module>queries</module>
     </modules>
 
     <dependencies>

--- a/src/it/tutorials/queries/pom.xml
+++ b/src/it/tutorials/queries/pom.xml
@@ -59,7 +59,7 @@
                     </execution>
                     <execution>
                         <id>queries2doc</id>
-                        <phase>pre-site</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>queries2doc</goal>
                         </goals>

--- a/src/it/tutorials/queries/pom.xml
+++ b/src/it/tutorials/queries/pom.xml
@@ -51,9 +51,17 @@
                 <version>${h4mp.version}</version>
                 <executions>
                     <execution>
+                        <id>extract-queries</id>
                         <phase>process-test-classes</phase>
                         <goals>
                             <goal>queries</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>queries2doc</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>queries2doc</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/it/tutorials/queries/pom.xml
+++ b/src/it/tutorials/queries/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ Copyright (c) 2010, Red Hat Inc. or third-party contributors as
+  ~ indicated by the @author tags or express copyright attribution
+  ~ statements applied by the authors.  All third-party contributions are
+  ~ distributed under license by Red Hat Inc.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use, modify,
+  ~ copy, or redistribute it subject to the terms and conditions of the GNU
+  ~ Lesser General Public License, as published by the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.tutorials</groupId>
+        <artifactId>hibernate-tutorials</artifactId>
+        <version>4.3.9.Final</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-tutorial-hbm-queries</artifactId>
+    <name>Hibernate hbm.xml queries Tutorial</name>
+    <description>Hibernate tutorial illustrating how to generate queries documentation</description>
+
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <h4mp.version>@project.version@</h4mp.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>de.juplo</groupId>
+                <artifactId>hibernate-maven-plugin</artifactId>
+                <version>${h4mp.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>queries</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanTestClasses>true</scanTestClasses>
+                    <format>true</format>
+                    <force>true</force>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/Event.hbm.xml
+++ b/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/Event.hbm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ Copyright (c) 2010, Red Hat Inc. or third-party contributors as
+  ~ indicated by the @author tags or express copyright attribution
+  ~ statements applied by the authors.  All third-party contributions are
+  ~ distributed under license by Red Hat Inc.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use, modify,
+  ~ copy, or redistribute it subject to the terms and conditions of the GNU
+  ~ Lesser General Public License, as published by the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+                   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping classpath://org/hibernate/hibernate-mapping-4.0.xsd"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   package="org.hibernate.tutorial.hbm">
+
+    <class name="Event" table="EVENTS">
+        <id name="id" column="EVENT_ID">
+            <generator class="increment"/>
+        </id>
+        <property name="date" type="timestamp" column="EVENT_DATE"/>
+        <property name="title"/>
+    </class>
+
+</hibernate-mapping>

--- a/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/Event.java
+++ b/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/Event.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.tutorial.hbm;
+
+import java.util.Date;
+
+public class Event {
+	private Long id;
+
+	private String title;
+	private Date date;
+
+	public Event() {
+		// this form used by Hibernate
+	}
+
+	public Event(String title, Date date) {
+		// for application use, to create new events
+		this.title = title;
+		this.date = date;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	private void setId(Long id) {
+		this.id = id;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/NativeApiIllustrationTest.java
+++ b/src/it/tutorials/queries/src/test/java/org/hibernate/tutorial/hbm/NativeApiIllustrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.tutorial.hbm;
+
+import java.util.Date;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+
+/**
+ * Illustrates use of Hibernate native APIs.
+ *
+ * @author Steve Ebersole
+ */
+public class NativeApiIllustrationTest extends TestCase {
+	private SessionFactory sessionFactory;
+
+	@Override
+	protected void setUp() throws Exception {
+		// A SessionFactory is set up once for an application
+        sessionFactory = new Configuration()
+                .configure() // configures settings from hibernate.cfg.xml
+                .buildSessionFactory();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		if ( sessionFactory != null ) {
+			sessionFactory.close();
+		}
+	}
+
+	public void testBasicUsage() {
+		// create a couple of events...
+		Session session = sessionFactory.openSession();
+		session.beginTransaction();
+		session.save( new Event( "Our very first event!", new Date() ) );
+		session.save( new Event( "A follow up event", new Date() ) );
+		session.getTransaction().commit();
+		session.close();
+
+		// now lets pull events from the database and list them
+		session = sessionFactory.openSession();
+        session.beginTransaction();
+        List result = session.createQuery( "from Event" ).list();
+		for ( Event event : (List<Event>) result ) {
+			System.out.println( "Event (" + event.getDate() + ") : " + event.getTitle() );
+		}
+        session.getTransaction().commit();
+        session.close();
+	}
+}

--- a/src/it/tutorials/queries/src/test/resources/hibernate.cfg.xml
+++ b/src/it/tutorials/queries/src/test/resources/hibernate.cfg.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ Copyright (c) 2010, Red Hat Inc. or third-party contributors as
+  ~ indicated by the @author tags or express copyright attribution
+  ~ statements applied by the authors.  All third-party contributions are
+  ~ distributed under license by Red Hat Inc.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use, modify,
+  ~ copy, or redistribute it subject to the terms and conditions of the GNU
+  ~ Lesser General Public License, as published by the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+
+    <session-factory>
+
+        <!-- Database connection settings -->
+        <property name="connection.driver_class">org.h2.Driver</property>
+        <property name="connection.url">jdbc:h2:${project.build.directory}/db/test;MVCC=TRUE</property>
+        <property name="connection.username">sa</property>
+        <property name="connection.password"/>
+
+        <!-- JDBC connection pool (use the built-in) -->
+        <property name="connection.pool_size">1</property>
+
+        <!-- SQL dialect -->
+        <property name="dialect">org.hibernate.dialect.H2Dialect</property>
+
+        <!-- Disable the second-level cache  -->
+        <property name="cache.provider_class">org.hibernate.cache.internal.NoCacheProvider</property>
+
+        <!-- Echo all executed SQL to stdout -->
+        <property name="show_sql">true</property>
+
+        <!-- Drop and re-create the database schema on startup -->
+        <property name="hbm2ddl.auto">create</property>
+
+        <mapping resource="org/hibernate/tutorial/hbm/Event.hbm.xml"/>
+        <mapping resource="queries.hbm.xml"/>
+    </session-factory>
+
+</hibernate-configuration>

--- a/src/it/tutorials/queries/src/test/resources/queries.hbm.xml
+++ b/src/it/tutorials/queries/src/test/resources/queries.hbm.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  #%L
+  SIH-Adagio Core for Allegro
+  $Id: queries.hbm.xml 13334 2016-08-26 20:38:09Z bl05b3e $
+  $HeadURL: https://forge.ifremer.fr/svn/sih-adagio/trunk/adagio/core-allegro/src/main/resources/queries.hbm.xml $
+  %%
+  Copyright (C) 2012 - 2013 Ifremer
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  #L%
+  -->
+
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+                   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping classpath://org/hibernate/hibernate-mapping-4.0.xsd"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <query cacheable="true" name="eventById" comment="Get event by id.&#10;Useful when loading event details">
+        <![CDATA[SELECT
+		  e.id
+		FROM
+		  org.hibernate.tutorial.hbm.Event e
+		WHERE e.id = :eventId]]>
+        <query-param name="eventId" type="java.lang.Integer" ></query-param>
+    </query>
+
+    <query cacheable="true" name="deleteEvent" comment="Delete an event">
+        <![CDATA[DELETE FROM
+		  org.hibernate.tutorial.hbm.Event e
+		WHERE e.id = :eventId]]>
+        <query-param name="eventId" type="java.lang.Integer" ></query-param>
+    </query>
+
+    <sql-query name="nativeEventById" comment="A native query to get event by id">
+        <![CDATA[
+            select
+                EVENT_ID
+            from
+                EVENTS
+            where
+                EVENT_ID=:eventId
+        ]]>
+        <query-param name="eventId" type="java.lang.Integer"></query-param>
+    </sql-query>
+</hibernate-mapping>

--- a/src/it/tutorials/verify.bsh
+++ b/src/it/tutorials/verify.bsh
@@ -17,3 +17,5 @@ if (!comparator.isEqual("schema-osgi-unmanaged-jpa.sql","osgi/unmanaged-jpa/targ
   return false;
 if (!comparator.isEqual("schema-osgi-unmanaged-native.sql","osgi/unmanaged-native/target/create.sql"))
   return false;
+if (!comparator.isEqual("extract-queries.sql","queries/target/queries.sql"))
+  return false;

--- a/src/main/java/de/juplo/plugins/hibernate/AbstractSchemaMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate/AbstractSchemaMojo.java
@@ -422,6 +422,9 @@ public abstract class AbstractSchemaMojo extends AbstractMojo
   private String mappings;
 
 
+  protected void setSkip(boolean skip) {
+    this.skip = skip;
+  }
 
   public final void execute(String filename)
     throws

--- a/src/main/java/de/juplo/plugins/hibernate/Queries2DocMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate/Queries2DocMojo.java
@@ -1,0 +1,119 @@
+package de.juplo.plugins.hibernate;
+
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.tool.hbm2ddl.QueriesExport;
+import org.hibernate.tool.hbm2doc.queries.Queries2DocExport;
+
+import java.io.File;
+
+
+/**
+ * Goal which extracts the hibernate-mapping-configuration and
+ * exports all queries to HTML documentation.
+ *
+ * @goal queries2doc
+ * @phase process-classes
+ * @threadSafe
+ * @requiresDependencyResolution runtime
+ */
+public class Queries2DocMojo extends AbstractSchemaMojo
+{
+  /**
+   * Output file.
+   * <p>
+   * Relative to
+   * (<code>project.build.directory</code>).
+   *
+   * @parameter property="hibernate.hbm2doc.queries.directory" default-value="site/queries/index.flt"
+   * @since 1.0
+   */
+  private String outputFile;
+
+  /**
+   * Skip execution
+   * <p>
+   * If set to <code>true</code>, the execution is skipped.
+   * <p>
+   * A skipped execution is signaled via the maven-property
+   * <code>${hibernate.schema.skipped}</code>.
+   * <p>
+   * The execution is skipped automatically, if no modified or newly added
+   * annotated classes are found and the dialect was not changed.
+   * <p>
+   * <strong>Important:</strong>
+   * This configuration value can only be configured through the
+   * <code>pom.xml</code>, or by the definition of a system-property, because
+   * it is not known by Hibernate nor JPA and, hence, not picked up from
+   * their configuration!
+   *
+   * @parameter property="hibernate.queries2doc.skip" default-value="${maven.site.skip}"
+   * @since 1.0
+   */
+  private boolean skip;
+
+  @Override
+  public final void execute()
+    throws
+      MojoFailureException,
+      MojoExecutionException
+  {
+    setSkip(skip);
+    super.execute(outputFile);
+  }
+
+  @Override
+  void build(MetadataImplementor metadata)
+      throws
+        MojoExecutionException,
+        MojoFailureException
+  {
+
+    Queries2DocExport queriesExport = new Queries2DocExport(metadata);
+    queriesExport.setDelimiter(delimiter);
+
+    File output = new File(outputFile);
+
+    if (!output.isAbsolute())
+    {
+      // Interpret relative file path relative to build directory
+      output = new File(buildDirectory, outputFile);
+      getLog().debug("Adjusted relative path, resulting path is " + output.getPath());
+    }
+
+    // Ensure that directory path for specified file exists
+    File outFileParentDir = output.getParentFile();
+    if (null != outFileParentDir && !outFileParentDir.exists())
+    {
+      try
+      {
+        getLog().info("Creating directory path for output file:" + outFileParentDir.getPath());
+        outFileParentDir.mkdirs();
+      }
+      catch (Exception e)
+      {
+        getLog().error("Error creating directory path for output file: " + e.getLocalizedMessage());
+      }
+    }
+
+    queriesExport.setOutputDirectory(output.getParentFile().getPath());
+    queriesExport.execute();
+  }
+}

--- a/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
@@ -43,11 +43,22 @@ public class QueriesMojo extends AbstractSchemaMojo
    * relative to the project build directory
    * (<code>project.build.directory</code>).
    *
-   * @parameter property="hibernate.schema.export.queries" default-value="queries.sql"
+   * @parameter property="hibernate.schema.export.queries" default-value="extract-queries.sql"
    * @since 1.0
    */
   private String outputFile;
 
+  /**
+   * Output file.
+   * <p>
+   * If the specified filename is not absolut, the file will be created
+   * relative to the project build directory
+   * (<code>project.build.directory</code>).
+   *
+   * @parameter property="hibernate.schema.export.queries" default-value="extract-queries.sql"
+   * @since 1.0
+   */
+  private String format;
 
   @Override
   public final void execute()

--- a/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
@@ -43,22 +43,10 @@ public class QueriesMojo extends AbstractSchemaMojo
    * relative to the project build directory
    * (<code>project.build.directory</code>).
    *
-   * @parameter property="hibernate.schema.export.queries" default-value="extract-queries.sql"
+   * @parameter property="hibernate.schema.export.queries" default-value="queries.sql"
    * @since 1.0
    */
   private String outputFile;
-
-  /**
-   * Output file.
-   * <p>
-   * If the specified filename is not absolut, the file will be created
-   * relative to the project build directory
-   * (<code>project.build.directory</code>).
-   *
-   * @parameter property="hibernate.schema.export.queries" default-value="extract-queries.sql"
-   * @since 1.0
-   */
-  private String format;
 
   @Override
   public final void execute()
@@ -106,7 +94,7 @@ public class QueriesMojo extends AbstractSchemaMojo
     }
 
     queriesExport.setOutputFile(output.getPath());
-    queriesExport.execute(false, false, true);
+    queriesExport.execute(false);
 
     for (Object exception : queriesExport.getExceptions())
       getLog().error(exception.toString());

--- a/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
+++ b/src/main/java/de/juplo/plugins/hibernate/QueriesMojo.java
@@ -1,0 +1,103 @@
+package de.juplo.plugins.hibernate;
+
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.tool.hbm2ddl.QueriesExport;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+
+import java.io.File;
+
+
+/**
+ * Goal which extracts the hibernate-mapping-configuration and
+ * exports an according SQL-database-schema.
+ *
+ * @goal queries
+ * @phase process-classes
+ * @threadSafe
+ * @requiresDependencyResolution runtime
+ */
+public class QueriesMojo extends AbstractSchemaMojo
+{
+  /**
+   * Output file.
+   * <p>
+   * If the specified filename is not absolut, the file will be created
+   * relative to the project build directory
+   * (<code>project.build.directory</code>).
+   *
+   * @parameter property="hibernate.schema.export.queries" default-value="queries.sql"
+   * @since 1.0
+   */
+  private String outputFile;
+
+
+  @Override
+  public final void execute()
+    throws
+      MojoFailureException,
+      MojoExecutionException
+  {
+    super.execute(outputFile);
+  }
+
+
+  @Override
+  void build(MetadataImplementor metadata)
+      throws
+        MojoExecutionException,
+        MojoFailureException
+  {
+
+    QueriesExport queriesExport = new QueriesExport(metadata);
+    queriesExport.setDelimiter(delimiter);
+    queriesExport.setFormat(format);
+
+    File output = new File(outputFile);
+
+    if (!output.isAbsolute())
+    {
+      // Interpret relative file path relative to build directory
+      output = new File(buildDirectory, outputFile);
+      getLog().debug("Adjusted relative path, resulting path is " + output.getPath());
+    }
+
+    // Ensure that directory path for specified file exists
+    File outFileParentDir = output.getParentFile();
+    if (null != outFileParentDir && !outFileParentDir.exists())
+    {
+      try
+      {
+        getLog().info("Creating directory path for output file:" + outFileParentDir.getPath());
+        outFileParentDir.mkdirs();
+      }
+      catch (Exception e)
+      {
+        getLog().error("Error creating directory path for output file: " + e.getLocalizedMessage());
+      }
+    }
+
+    queriesExport.setOutputFile(output.getPath());
+    queriesExport.execute(false, false, true);
+
+    for (Object exception : queriesExport.getExceptions())
+      getLog().error(exception.toString());
+  }
+}

--- a/src/main/java/org/hibernate/tool/hbm2ddl/QueriesExport.java
+++ b/src/main/java/org/hibernate/tool/hbm2ddl/QueriesExport.java
@@ -1,0 +1,691 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.hbm2ddl;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.*;
+
+import com.google.common.collect.Lists;
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
+import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.engine.query.spi.HQLQueryPlan;
+import org.hibernate.engine.spi.NamedQueryDefinition;
+import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.hql.internal.ast.ASTQueryTranslatorFactory;
+import org.hibernate.hql.spi.QueryTranslator;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.log.DeprecationLogger;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.service.ServiceRegistry;
+
+/**
+ * Commandline tool to export named queries into a sql file. This class may also be called from inside an application.
+ *
+ * @author Benoit Lavenier
+ */
+public class QueriesExport {
+	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( QueriesExport.class );
+
+	private static final String DEFAULT_IMPORT_FILE = "/queries.sql";
+
+	public static enum Type {
+		SQL,
+		HQL,
+		BOTH,
+		NONE;
+
+		public boolean doSql() {
+			return this == SQL || this == BOTH;
+		}
+
+		public boolean doHql() {
+			return this == HQL || this == BOTH;
+		}
+	}
+
+	private final ConnectionHelper connectionHelper;
+	private final SqlStatementLogger sqlStatementLogger;
+	private final SqlExceptionHelper sqlExceptionHelper;
+	private final ClassLoaderService classLoaderService;
+	private final String[] queriesSQL;
+	private final String importFiles;
+
+	private final List<Exception> exceptions = new ArrayList<Exception>();
+
+	private Formatter formatter;
+	private ImportSqlCommandExtractor importSqlCommandExtractor = ImportSqlCommandExtractorInitiator.DEFAULT_EXTRACTOR;
+
+	private String outputFile;
+	private String delimiter;
+
+	/**
+	 * Builds a QueriesExport object.
+	 *
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 */
+	public QueriesExport(MetadataImplementor metadata) {
+		this( metadata.getMetadataBuildingOptions().getServiceRegistry(), metadata);
+	}
+
+	/**
+	 * Builds a QueriesExport object.
+	 *
+	 * @param serviceRegistry The registry of services available for use.  Should, at a minimum, contain
+	 * the JdbcServices service.
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 */
+	public QueriesExport(ServiceRegistry serviceRegistry, MetadataImplementor metadata) {
+		this(
+				new SuppliedConnectionProviderConnectionHelper(
+						serviceRegistry.getService( ConnectionProvider.class )
+				),
+				serviceRegistry,
+				metadata
+		);
+	}
+
+	private QueriesExport(
+			ConnectionHelper connectionHelper,
+			ServiceRegistry serviceRegistry,
+			MetadataImplementor metadata) {
+		this.connectionHelper = connectionHelper;
+		this.sqlStatementLogger = serviceRegistry.getService( JdbcServices.class ).getSqlStatementLogger();
+		this.formatter = ( sqlStatementLogger.isFormat() ? FormatStyle.BASIC : FormatStyle.NONE ).getFormatter();
+		this.sqlExceptionHelper = serviceRegistry.getService( JdbcEnvironment.class ).getSqlExceptionHelper();
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+
+		this.importFiles = ConfigurationHelper.getString(
+				AvailableSettings.HBM2DDL_IMPORT_FILES,
+				serviceRegistry.getService( ConfigurationService.class ).getSettings(),
+				DEFAULT_IMPORT_FILE
+		);
+
+		//final JdbcServices jdbcServices = serviceRegistry.getService( JdbcServices.class );
+
+		SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor)metadata.buildSessionFactory();
+		ASTQueryTranslatorFactory queryTranslatorFactory = new ASTQueryTranslatorFactory();
+
+		List<String> lines = Lists.newArrayList();
+
+		// named queries
+		for (NamedQueryDefinition queryDef: metadata.getNamedQueryDefinitions()) {
+			String name = queryDef.getName();
+			String comment = queryDef.getComment();
+			String hql = queryDef.getQueryString();
+			Map<String, String> params = queryDef.getParameterTypes();
+
+			// Convert HQL to SQL
+			QueryTranslator queryTranslator = queryTranslatorFactory.createQueryTranslator(name,
+					hql, java.util.Collections.EMPTY_MAP, sessionFactory, null);
+			queryTranslator.compile(java.util.Collections.EMPTY_MAP, false);
+			String sql;
+			if (queryTranslator.isManipulationStatement()) {
+				// Add to the result list
+				addQuery(lines, name, comment, params, hql, null);
+				for (String line: queryTranslator.collectSqlStrings()) {
+					lines.add(line);
+				}
+			}
+			else {
+				sql = queryTranslator.getSQLString();
+				// Add to the result list
+				addQuery(lines, name, comment, params, hql, sql);
+			}
+
+		}
+
+		// native queries
+		for (NamedSQLQueryDefinition queryDef: metadata.getNamedNativeQueryDefinitions()) {
+			String name = queryDef.getName();
+			String comment = queryDef.getComment();
+			String sql = queryDef.getQueryString();
+			Map<String, String> params = queryDef.getParameterTypes();
+
+			// Add to the result list
+			addQuery(lines, name, comment, params, null, sql);
+		}
+
+		this.queriesSQL = lines.toArray( new String[lines.size()] );
+	}
+
+	/**
+	 * Intended for testing use
+	 *
+	 * @param connectionHelper Access to the JDBC Connection
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 */
+	public QueriesExport(
+			ConnectionHelper connectionHelper,
+			MetadataImplementor metadata) {
+		this(
+				connectionHelper,
+				metadata.getMetadataBuildingOptions().getServiceRegistry(),
+				metadata
+		);
+	}
+
+	/**
+	 * Create a QueriesExport for the given Metadata, using the supplied connection for connectivity.
+	 *
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 * @param connection The JDBC connection to use.
+	 *
+	 * @throws HibernateException Indicates problem preparing for schema export.
+	 */
+	public QueriesExport(MetadataImplementor metadata, Connection connection) throws HibernateException {
+		this( new SuppliedConnectionHelper( connection ), metadata );
+	}
+
+	/**
+	 * @deprecated Use one of the forms accepting {@link MetadataImplementor}, rather
+	 * than {@link Configuration}, instead.
+	 */
+	@Deprecated
+	public QueriesExport(ServiceRegistry serviceRegistry, Configuration configuration) {
+		throw new UnsupportedOperationException(
+				"Attempt to use unsupported QueriesExport constructor accepting org.hibernate.cfg.Configuration; " +
+						"one of the forms accepting org.hibernate.boot.spi.MetadataImplementor should be used instead"
+		);
+	}
+
+	/**
+	 * @deprecated Use one of the forms accepting {@link MetadataImplementor}, rather
+	 * than {@link Configuration}, instead.
+	 */
+	@Deprecated
+	public QueriesExport(Configuration configuration) {
+		throw new UnsupportedOperationException(
+				"Attempt to use unsupported QueriesExport constructor accepting org.hibernate.cfg.Configuration; " +
+						"one of the forms accepting org.hibernate.boot.spi.MetadataImplementor should be used instead"
+		);
+	}
+
+	/**
+	 * @deprecated Use one of the forms accepting {@link MetadataImplementor}, rather
+	 * than {@link Configuration}, instead.
+	 */
+	@Deprecated
+	public QueriesExport(Configuration configuration, Connection connection) throws HibernateException {
+		throw new UnsupportedOperationException(
+				"Attempt to use unsupported QueriesExport constructor accepting org.hibernate.cfg.Configuration; " +
+						"one of the forms accepting org.hibernate.boot.spi.MetadataImplementor should be used instead"
+		);
+	}
+
+	public QueriesExport(
+			ConnectionHelper connectionHelper,
+			String[] createSql) {
+		this.connectionHelper = connectionHelper;
+		this.queriesSQL = createSql;
+		this.importFiles = "";
+		this.sqlStatementLogger = new SqlStatementLogger( false, true );
+		this.sqlExceptionHelper = new SqlExceptionHelper();
+		this.classLoaderService = new ClassLoaderServiceImpl();
+		this.formatter = FormatStyle.BASIC.getFormatter();
+	}
+
+	/**
+	 * For generating a export script file, this is the file which will be written.
+	 *
+	 * @param filename The name of the file to which to write the export script.
+	 *
+	 * @return this
+	 */
+	public QueriesExport setOutputFile(String filename) {
+		outputFile = filename;
+		return this;
+	}
+
+	/**
+	 * Set the end of statement delimiter
+	 *
+	 * @param delimiter The delimiter
+	 *
+	 * @return this
+	 */
+	public QueriesExport setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+		return this;
+	}
+
+	/**
+	 * Should we format the sql strings?
+	 *
+	 * @param format Should we format SQL strings
+	 *
+	 * @return this
+	 */
+	public QueriesExport setFormat(boolean format) {
+		this.formatter = ( format ? FormatStyle.BASIC : FormatStyle.NONE ).getFormatter();
+		return this;
+	}
+
+	/**
+	 * Set <i>import.sql</i> command extractor. By default {@link org.hibernate.tool.hbm2ddl.SingleLineSqlCommandExtractor} is used.
+	 *
+	 * @param importSqlCommandExtractor <i>import.sql</i> command extractor.
+	 *
+	 * @return this
+	 */
+	public QueriesExport setImportSqlCommandExtractor(ImportSqlCommandExtractor importSqlCommandExtractor) {
+		this.importSqlCommandExtractor = importSqlCommandExtractor;
+		return this;
+	}
+
+	/**
+	 * Run the schema creation script; drop script is automatically
+	 * executed before running the creation script.
+	 *
+	 * @param script print quaries to the console
+	 * @param export export the script to the database
+	 */
+	public void create(boolean script, boolean export) {
+		create( Target.interpret( script, export ) );
+	}
+
+	/**
+	 * Run the schema creation script; hql script is automatically
+	 * written before writing the SQL script.
+	 *
+	 * @param output the target of the script.
+	 */
+	public void create(Target output) {
+		// need to drop tables before creating so need to specify Type.BOTH
+		execute( output, Type.BOTH );
+	}
+
+	public void execute(boolean script, boolean justHql, boolean justSql) {
+		execute( Target.interpret( script, false/*export*/), interpretType( justHql, justSql ) );
+	}
+
+	private Type interpretType(boolean justHql, boolean justSql) {
+		if ( justHql ) {
+			return Type.HQL;
+		}
+		else if ( justSql ) {
+			return Type.SQL;
+		}
+		else {
+			return Type.BOTH;
+		}
+	}
+
+	public void execute(Target output, Type type) {
+		if ( ( outputFile == null && output == Target.NONE ) || type == QueriesExport.Type.NONE ) {
+			return;
+		}
+		exceptions.clear();
+
+		LOG.info("Starting queries extraction");
+
+		final List<NamedReader> importFileReaders = new ArrayList<NamedReader>();
+		for ( String currentFile : importFiles.split( "," ) ) {
+			final String resourceName = currentFile.trim();
+
+			InputStream stream = classLoaderService.locateResourceStream( resourceName );
+			if ( stream == null ) {
+				LOG.debugf( "Import file not found: %s", currentFile );
+			}
+			else {
+				importFileReaders.add( new NamedReader( resourceName, stream ) );
+			}
+		}
+
+		final List<Exporter> exporters = new ArrayList<Exporter>();
+		try {
+			// prepare exporters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			if ( output.doScript() ) {
+				exporters.add( new ScriptExporter() );
+			}
+			if ( outputFile != null ) {
+				exporters.add( new FileExporter( outputFile ) );
+			}
+
+			// perform exporters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			if ( type.doSql() ) {
+				perform(queriesSQL, exporters );
+				if ( !importFileReaders.isEmpty() ) {
+					for ( NamedReader namedReader : importFileReaders ) {
+						importScript( namedReader, exporters );
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			exceptions.add( e );
+			LOG.error("Could not extract queries", e);
+		}
+		finally {
+			// release exporters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			for ( Exporter exporter : exporters ) {
+				try {
+					exporter.release();
+				}
+				catch (Exception ignore) {
+				}
+			}
+
+			// release the named readers from import scripts
+			for ( NamedReader namedReader : importFileReaders ) {
+				try {
+					namedReader.getReader().close();
+				}
+				catch (Exception ignore) {
+				}
+			}
+			LOG.info("Successfully extract queries");
+		}
+	}
+
+	private void perform(String[] lines, List<Exporter> exporters) {
+		for ( String line : lines ) {
+			String formatted;
+			if (line.trim().length() > 0 && !line.startsWith("--")) {
+				formatted = formatter.format(line);
+				if (delimiter != null) {
+					formatted += delimiter;
+				}
+				sqlStatementLogger.logStatement( line, formatter );
+			}
+			else {
+				formatted = line;
+			}
+			for ( Exporter exporter : exporters ) {
+				try {
+					exporter.export( formatted );
+				}
+				catch (Exception e) {
+					exceptions.add( e );
+					LOG.debug("Unable to perform command: " + line );
+					LOG.error( e.getMessage() );
+				}
+			}
+		}
+	}
+
+	private void importScript(NamedReader namedReader, List<Exporter> exporters) throws Exception {
+		BufferedReader reader = new BufferedReader( namedReader.getReader() );
+		String[] statements = importSqlCommandExtractor.extractCommands( reader );
+		if ( statements != null ) {
+			for ( String statement : statements ) {
+				if ( statement != null ) {
+					String trimmedSql = statement.trim();
+					if ( trimmedSql.endsWith( ";" ) ) {
+						trimmedSql = trimmedSql.substring( 0, statement.length() - 1 );
+					}
+					if ( !StringHelper.isEmpty( trimmedSql ) ) {
+						try {
+							for ( Exporter exporter : exporters ) {
+								if ( exporter.acceptsImportScripts() ) {
+									exporter.export( trimmedSql );
+								}
+							}
+						}
+						catch (Exception e) {
+							exceptions.add( e );
+							LOG.unsuccessful( trimmedSql );
+							LOG.error( e.getMessage() );
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private void addQuery(List<String> lines, String name, String comment, Map<String, String> params, String hql, String sql) {
+
+		// header
+		if (lines.size() == 0) {
+			lines.add("--");
+			lines.add("-- Queries extraction file");
+			lines.add("--");
+		}
+		else {
+			lines.add("");
+			lines.add("");
+		}
+		lines.add("-- ************************************************************");
+
+		// Comment
+		if (comment != null && comment.trim().length() > 0) {
+			String[] commentLines = comment.trim().split("\n");
+			for (String line: commentLines) {
+				lines.add("-- " + line.trim());
+			}
+			lines.add("--");
+		}
+
+		// name
+		lines.add("-- @name\t\t\t" + name);
+
+		// parameters
+		if (params != null && !params.isEmpty()) {
+			for (String paramName: params.keySet()) {
+				String paramType = params.get(paramName);
+				lines.add(String.format("-- @param\t\t\t%s\t\t%s", paramName, paramType));
+			}
+		}
+
+		// hql
+		if (hql != null && hql.trim().length() > 0) {
+			lines.add("--");
+			lines.add("-- @hql");
+			String[] hqlLines = hql.trim().split("\n");
+			for (String line : hqlLines) {
+				if (line.trim().length() > 0) {
+					lines.add("--   " + line);
+				}
+			}
+		}
+		lines.add("--");
+
+
+		lines.add("-- ************************************************************");
+
+		// sql (could be null)
+		if (sql != null && sql.trim().length() > 0) {
+			lines.add(sql.trim());
+		}
+	}
+
+	private static class NamedReader {
+		private final Reader reader;
+		private final String name;
+
+		public NamedReader(String name, InputStream stream) {
+			this.name = name;
+			this.reader = new InputStreamReader( stream );
+		}
+
+		public Reader getReader() {
+			return reader;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	public static void main(String[] args) {
+		try {
+			final CommandLineArgs commandLineArgs = CommandLineArgs.parseCommandLineArgs( args );
+			StandardServiceRegistry serviceRegistry = buildStandardServiceRegistry( commandLineArgs );
+			try {
+				final MetadataImplementor metadata = buildMetadata( commandLineArgs, serviceRegistry );
+
+				QueriesExport queriesExport = new QueriesExport( serviceRegistry, metadata)
+						.setOutputFile( commandLineArgs.outputFile )
+						.setDelimiter( commandLineArgs.delimiter )
+						.setImportSqlCommandExtractor( serviceRegistry.getService( ImportSqlCommandExtractor.class ) )
+						.setFormat( commandLineArgs.format );
+				queriesExport.execute(
+						commandLineArgs.script,
+						commandLineArgs.hql,
+						commandLineArgs.sql
+				);
+			}
+			finally {
+				StandardServiceRegistryBuilder.destroy( serviceRegistry );
+			}
+		}
+		catch (Exception e) {
+			LOG.unableToCreateSchema( e );
+			e.printStackTrace();
+		}
+	}
+
+	private static StandardServiceRegistry buildStandardServiceRegistry(CommandLineArgs commandLineArgs)
+			throws Exception {
+		final BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder().build();
+		final StandardServiceRegistryBuilder ssrBuilder = new StandardServiceRegistryBuilder( bsr );
+
+		if ( commandLineArgs.cfgXmlFile != null ) {
+			ssrBuilder.configure( commandLineArgs.cfgXmlFile );
+		}
+
+		Properties properties = new Properties();
+		if ( commandLineArgs.propertiesFile != null ) {
+			properties.load( new FileInputStream( commandLineArgs.propertiesFile ) );
+		}
+		ssrBuilder.applySettings( properties );
+
+		if ( commandLineArgs.importFile != null ) {
+			ssrBuilder.applySetting( AvailableSettings.HBM2DDL_IMPORT_FILES, commandLineArgs.importFile );
+		}
+
+		return ssrBuilder.build();
+	}
+
+	private static MetadataImplementor buildMetadata(
+			CommandLineArgs parsedArgs,
+			StandardServiceRegistry serviceRegistry) throws Exception {
+		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
+
+		for ( String filename : parsedArgs.hbmXmlFiles ) {
+			metadataSources.addFile( filename );
+		}
+
+		for ( String filename : parsedArgs.jarFiles ) {
+			metadataSources.addJar( new File( filename ) );
+		}
+
+
+		final MetadataBuilder metadataBuilder = metadataSources.getMetadataBuilder();
+
+		return (MetadataImplementor) metadataBuilder.build();
+	}
+
+	/**
+	 * Returns a List of all Exceptions which occured during the export.
+	 *
+	 * @return A List containig the Exceptions occured during the export
+	 */
+	public List getExceptions() {
+		return exceptions;
+	}
+
+	private static class CommandLineArgs {
+		boolean script = true;
+		boolean hql = false;
+		boolean sql = false;
+		boolean format = false;
+
+		String delimiter = null;
+
+		String outputFile = null;
+		String importFile = DEFAULT_IMPORT_FILE;
+
+		String propertiesFile = null;
+		String cfgXmlFile = null;
+
+		List<String> hbmXmlFiles = new ArrayList<String>();
+		List<String> jarFiles = new ArrayList<String>();
+
+		public static CommandLineArgs parseCommandLineArgs(String[] args) {
+			CommandLineArgs parsedArgs = new CommandLineArgs();
+
+			for ( String arg : args ) {
+				if ( arg.startsWith( "--" ) ) {
+					if ( arg.equals( "--quiet" ) ) {
+						parsedArgs.script = false;
+					}
+					else if ( arg.equals( "--hql" ) ) {
+						parsedArgs.hql = true;
+					}
+					else if ( arg.equals( "--sql" ) ) {
+						parsedArgs.sql = true;
+					}
+					else if ( arg.startsWith( "--output=" ) ) {
+						parsedArgs.outputFile = arg.substring( 9 );
+					}
+					else if ( arg.startsWith( "--import=" ) ) {
+						parsedArgs.importFile = arg.substring( 9 );
+					}
+					else if ( arg.startsWith( "--properties=" ) ) {
+						parsedArgs.propertiesFile = arg.substring( 13 );
+					}
+					else if ( arg.equals( "--format" ) ) {
+						parsedArgs.format = true;
+					}
+					else if ( arg.startsWith( "--delimiter=" ) ) {
+						parsedArgs.delimiter = arg.substring( 12 );
+					}
+					else if ( arg.startsWith( "--config=" ) ) {
+						parsedArgs.cfgXmlFile = arg.substring( 9 );
+					}
+					else if ( arg.startsWith( "--naming=" ) ) {
+						DeprecationLogger.DEPRECATION_LOGGER.logDeprecatedNamingStrategyArgument();
+					}
+				}
+				else {
+					if ( arg.endsWith( ".jar" ) ) {
+						parsedArgs.jarFiles.add( arg );
+					}
+					else {
+						parsedArgs.hbmXmlFiles.add( arg );
+					}
+				}
+			}
+
+			return parsedArgs;
+		}
+	}
+}

--- a/src/main/java/org/hibernate/tool/hbm2ddl/QueriesExport.java
+++ b/src/main/java/org/hibernate/tool/hbm2ddl/QueriesExport.java
@@ -64,7 +64,7 @@ import org.hibernate.service.ServiceRegistry;
 public class QueriesExport {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( QueriesExport.class );
 
-	private static final String DEFAULT_IMPORT_FILE = "/queries.sql";
+	private static final String DEFAULT_IMPORT_FILE = "/extract-queries.sql";
 
 	public static enum Type {
 		SQL,

--- a/src/main/java/org/hibernate/tool/hbm2doc/queries/Queries2DocExport.java
+++ b/src/main/java/org/hibernate/tool/hbm2doc/queries/Queries2DocExport.java
@@ -210,8 +210,7 @@ public class Queries2DocExport {
 		Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
 
 		String packagePath = "org/hibernate/tool/hbm2doc/queries";
-		//cfg.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "/org/hibernate/tool/hbm2doc/queries");
-		cfg.setDirectoryForTemplateLoading(new File("/home/blavenie/git/blavenie/hibernate4-maven-plugin/src/main/resources/org/hibernate/tool/hbm2doc/queries"));
+		cfg.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "/org/hibernate/tool/hbm2doc/queries");
 
 		cfg.setDefaultEncoding("UTF-8");
 		// During web page *development* TemplateExceptionHandler.HTML_DEBUG_HANDLER is better.

--- a/src/main/java/org/hibernate/tool/hbm2doc/queries/Queries2DocExport.java
+++ b/src/main/java/org/hibernate/tool/hbm2doc/queries/Queries2DocExport.java
@@ -1,0 +1,445 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.hbm2doc.queries;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.template.*;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.engine.jdbc.StreamUtils;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.hibernate.engine.spi.NamedQueryDefinition;
+import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.internal.ast.ASTQueryTranslatorFactory;
+import org.hibernate.hql.spi.QueryTranslator;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.log.DeprecationLogger;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.hbm2ddl.*;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Commandline tool to export named queries into a sql file. This class may also be called from inside an application.
+ *
+ * @author Benoit Lavenier
+ */
+public class Queries2DocExport {
+	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( Queries2DocExport.class );
+
+	private final ClassLoaderService classLoaderService;
+
+	private Formatter formatter;
+	private ImportSqlCommandExtractor importSqlCommandExtractor = ImportSqlCommandExtractorInitiator.DEFAULT_EXTRACTOR;
+
+	private String outputDirectory;
+	private String delimiter;
+
+	private List<DocQuery> queries = new ArrayList<DocQuery>();
+
+	/**
+	 * Builds a QueriesExport object.
+	 *
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 */
+	public Queries2DocExport(MetadataImplementor metadata) {
+		this( metadata.getMetadataBuildingOptions().getServiceRegistry(), metadata);
+	}
+
+	/**
+	 * Builds a QueriesExport object.
+	 *
+	 * @param serviceRegistry The registry of services available for use.  Should, at a minimum, contain
+	 * the JdbcServices service.
+	 * @param metadata The metadata object holding the mapping info to be exported
+	 */
+	public Queries2DocExport(
+			ServiceRegistry serviceRegistry,
+			MetadataImplementor metadata) {
+		this.formatter = FormatStyle.BASIC.getFormatter();
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+
+		SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor)metadata.buildSessionFactory();
+		ASTQueryTranslatorFactory queryTranslatorFactory = new ASTQueryTranslatorFactory();
+
+		// named queries
+		for (NamedQueryDefinition queryDef: metadata.getNamedQueryDefinitions()) {
+			String name = queryDef.getName();
+			String comment = queryDef.getComment();
+			String hql = queryDef.getQueryString();
+			Map<String, String> params = queryDef.getParameterTypes();
+
+			// Convert HQL to SQL
+			QueryTranslator queryTranslator = queryTranslatorFactory.createQueryTranslator(name,
+					hql, java.util.Collections.EMPTY_MAP, sessionFactory, null);
+			queryTranslator.compile(java.util.Collections.EMPTY_MAP, false);
+
+			DocQuery docQuery;
+			if (queryTranslator.isManipulationStatement()) {
+				// Add to the result list
+				List<String> sql = new ArrayList<String>();
+				for (String line: queryTranslator.collectSqlStrings()) {
+					String formatted = formatter.format(line);
+					if (delimiter != null) {
+						formatted += delimiter;
+					}
+					sql.add(formatted.trim());
+				}
+				docQuery = new DocQuery(name, comment, params, hql.trim(), sql);
+			}
+			else {
+				String sql = queryTranslator.getSQLString();
+				if (sql != null) {
+					sql = formatter.format(sql);
+					if (delimiter != null) {
+						sql += delimiter;
+					}
+				}
+				docQuery = new DocQuery(name, comment, params, hql.trim(), sql != null ? sql.trim() : null);
+			}
+			queries.add(docQuery);
+		}
+
+		// native queries
+		for (NamedSQLQueryDefinition queryDef: metadata.getNamedNativeQueryDefinitions()) {
+			String name = queryDef.getName();
+			String comment = queryDef.getComment();
+			String sql = queryDef.getQueryString();
+			Map<String, String> params = queryDef.getParameterTypes();
+
+			// Add to the result list
+			DocQuery docQuery = new DocQuery(name, comment, params, null, sql != null ? sql.trim() : null);
+			queries.add(docQuery);
+		}
+	}
+
+	/**
+	 * For generating a doc on queries, this is the output directory.
+	 *
+	 * @param dirname The path of output directory, to write the generated doc.
+	 *
+	 * @return this
+	 */
+	public Queries2DocExport setOutputDirectory(String dirname) {
+		outputDirectory= dirname;
+		return this;
+	}
+
+	/**
+	 * Set the end of statement delimiter
+	 *
+	 * @param delimiter The delimiter
+	 *
+	 * @return this
+	 */
+	public Queries2DocExport setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+		return this;
+	}
+
+	/**
+	 * Set <i>import.sql</i> command extractor. By default {@link SingleLineSqlCommandExtractor} is used.
+	 *
+	 * @param importSqlCommandExtractor <i>import.sql</i> command extractor.
+	 *
+	 * @return this
+	 */
+	public Queries2DocExport setImportSqlCommandExtractor(ImportSqlCommandExtractor importSqlCommandExtractor) {
+		this.importSqlCommandExtractor = importSqlCommandExtractor;
+		return this;
+	}
+
+	/**
+	 * Run the queries extraction
+	 *
+	 */
+	public void execute() {
+		if (outputDirectory == null ) {
+			return;
+		}
+
+		LOG.info("Starting queries doc generation");
+
+		try {
+			perform();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			LOG.error("Could not generate queries doc", e);
+		}
+		finally {
+			LOG.info("Successfully generate queries doc");
+		}
+	}
+
+	private void perform() throws Exception {
+
+		Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+
+		String packagePath = "org/hibernate/tool/hbm2doc/queries";
+		//cfg.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "/org/hibernate/tool/hbm2doc/queries");
+		cfg.setDirectoryForTemplateLoading(new File("/home/blavenie/git/blavenie/hibernate4-maven-plugin/src/main/resources/org/hibernate/tool/hbm2doc/queries"));
+
+		cfg.setDefaultEncoding("UTF-8");
+		// During web page *development* TemplateExceptionHandler.HTML_DEBUG_HANDLER is better.
+		//TODO : cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+		cfg.setTemplateExceptionHandler(TemplateExceptionHandler.HTML_DEBUG_HANDLER);
+
+		cfg.setLogTemplateExceptions(true);
+
+		SimpleHash root = new SimpleHash(cfg.getObjectWrapper());
+		root.put("queries", queries);
+
+		// Generate index.flt
+		generateFile(cfg, root, "index.flt", "index.html");
+
+		// Generate summary.html
+		generateFile(cfg, root, "queries-summary.flt", "queries-summary.html");
+
+		// Generate allqueries.flt
+		generateFile(cfg, root, "allqueries.flt", "allqueries.html");
+
+		// TODO gen file for each query
+		//
+
+		copyFile(packagePath, "assets/doc-style.css");
+	}
+
+	private void generateFile(Configuration cfg, SimpleHash root, String template, String outputFilename)
+			throws IOException, TemplateException {
+
+		LOG.debug("Generating " + outputFilename);
+
+		Template temp = cfg.getTemplate(template);
+		File outputFile = new File(outputDirectory, outputFilename);
+
+		Writer out = null;
+		try {
+			out = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)));
+			temp.process(root, out);
+		}
+		finally {
+			if (out != null) {
+				try {
+					out.close();
+				}
+				catch(Exception e) {
+					// Silent
+				}
+			}
+		}
+
+	}
+
+	private void copyFile(String packagePath, String ressourceFilePath)
+			throws IOException, TemplateException {
+		copyFile(packagePath, ressourceFilePath, ressourceFilePath);
+	}
+
+	private void copyFile(String packagePath, String ressourceFilePath, String outputFilename)
+			throws IOException, TemplateException {
+
+		LOG.debug("Copying file " + outputFilename);
+		File outputFile = new File(outputDirectory, outputFilename);
+		if (!outputFile.getParentFile().exists()) {
+			outputFile.getParentFile().mkdirs();
+		}
+		OutputStream out = null;
+		InputStream is = null;
+		try {
+			out = new BufferedOutputStream(new FileOutputStream(outputFile));
+			is = this.getClass().getClassLoader().getResourceAsStream(packagePath + "/" + ressourceFilePath);
+			StreamUtils.copy(is, out, 2048);
+		}
+		finally {
+			if (out != null) {
+				try {
+					out.close();
+				}
+				catch(Exception e) {
+					// Silent
+				}
+			}
+			if (is != null) {
+				try {
+					is.close();
+				}
+				catch(Exception e) {
+					// Silent
+				}
+			}
+		}
+
+	}
+
+	public static class DocQuery {
+		private final String name;
+		private final String comment;
+		private final Map<String, String> params;
+		private final String hql;
+		private final List<String> sql;
+
+		public DocQuery(String name, String comment, Map<String, String> params, String hql, String sql) {
+			this(name, comment, params, hql, newList(sql));
+		}
+
+		public DocQuery(String name, String comment, Map<String, String> params, String hql, List<String> sql) {
+			this.name = name;
+			this.comment = comment;
+			this.params = params;
+			this.hql = hql;
+			this.sql = sql;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getComment() {
+			return comment;
+		}
+
+		public Map<String, String> getParams() {
+			return params;
+		}
+
+		public String getHql() {
+			return hql;
+		}
+
+		public List<String> getSql() {
+			return sql;
+		}
+
+		private static List<String> newList(String sql) {
+			List<String> result = new ArrayList<String>();
+			result.add(sql);
+			return  result;
+		}
+	}
+
+	public static void main(String[] args) {
+		try {
+			final CommandLineArgs commandLineArgs = CommandLineArgs.parseCommandLineArgs( args );
+			StandardServiceRegistry serviceRegistry = buildStandardServiceRegistry( commandLineArgs );
+			try {
+				final MetadataImplementor metadata = buildMetadata( commandLineArgs, serviceRegistry );
+
+				Queries2DocExport queriesExport = new Queries2DocExport( serviceRegistry, metadata)
+						.setOutputDirectory(commandLineArgs.outputDirectory)
+						.setDelimiter( commandLineArgs.delimiter )
+						.setImportSqlCommandExtractor( serviceRegistry.getService( ImportSqlCommandExtractor.class ) );
+				queriesExport.execute();
+			}
+			finally {
+				StandardServiceRegistryBuilder.destroy( serviceRegistry );
+			}
+		}
+		catch (Exception e) {
+			LOG.unableToCreateSchema( e );
+			e.printStackTrace();
+		}
+	}
+
+	private static StandardServiceRegistry buildStandardServiceRegistry(CommandLineArgs commandLineArgs)
+			throws Exception {
+		final BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder().build();
+		final StandardServiceRegistryBuilder ssrBuilder = new StandardServiceRegistryBuilder( bsr );
+
+		if ( commandLineArgs.cfgXmlFile != null ) {
+			ssrBuilder.configure( commandLineArgs.cfgXmlFile );
+		}
+
+		Properties properties = new Properties();
+		if ( commandLineArgs.propertiesFile != null ) {
+			properties.load( new FileInputStream( commandLineArgs.propertiesFile ) );
+		}
+		ssrBuilder.applySettings( properties );
+
+		return ssrBuilder.build();
+	}
+
+	private static MetadataImplementor buildMetadata(
+			CommandLineArgs parsedArgs,
+			StandardServiceRegistry serviceRegistry) throws Exception {
+		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
+
+		for ( String filename : parsedArgs.hbmXmlFiles ) {
+			metadataSources.addFile( filename );
+		}
+
+		for ( String filename : parsedArgs.jarFiles ) {
+			metadataSources.addJar( new File( filename ) );
+		}
+
+
+		final MetadataBuilder metadataBuilder = metadataSources.getMetadataBuilder();
+
+		return (MetadataImplementor) metadataBuilder.build();
+	}
+
+	private static class CommandLineArgs {
+		String delimiter = null;
+
+		String outputDirectory = null;
+		String propertiesFile = null;
+		String cfgXmlFile = null;
+
+		List<String> hbmXmlFiles = new ArrayList<String>();
+		List<String> jarFiles = new ArrayList<String>();
+
+		public static CommandLineArgs parseCommandLineArgs(String[] args) {
+			CommandLineArgs parsedArgs = new CommandLineArgs();
+
+			for ( String arg : args ) {
+				if ( arg.startsWith( "--" ) ) {
+					if ( arg.startsWith( "--output=" ) ) {
+						parsedArgs.outputDirectory = arg.substring( 9 );
+					}
+					else if ( arg.startsWith( "--properties=" ) ) {
+						parsedArgs.propertiesFile = arg.substring( 13 );
+					}
+					else if ( arg.startsWith( "--delimiter=" ) ) {
+						parsedArgs.delimiter = arg.substring( 12 );
+					}
+					else if ( arg.startsWith( "--config=" ) ) {
+						parsedArgs.cfgXmlFile = arg.substring( 9 );
+					}
+					else if ( arg.startsWith( "--naming=" ) ) {
+						DeprecationLogger.DEPRECATION_LOGGER.logDeprecatedNamingStrategyArgument();
+					}
+				}
+				else {
+					if ( arg.endsWith( ".jar" ) ) {
+						parsedArgs.jarFiles.add( arg );
+					}
+					else {
+						parsedArgs.hbmXmlFiles.add( arg );
+					}
+				}
+			}
+
+			return parsedArgs;
+		}
+	}
+}

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/allqueries.flt
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/allqueries.flt
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+<head>
+    <title>Hibernate Mappings - Entity List</title>
+    <link rel="stylesheet" type="text/css" href="assets/doc-style.css" title="Style"/>
+</head>
+<body class="List">
+
+<p class="ListTitleFont">
+    All Queries
+</p>
+
+<p>
+<#list queries as q>
+    <a href="queries-summary.html#${q.name}" target="generalFrame">${q.name}</a><br/>
+</#list>
+</p>
+
+</body>
+</html>

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/assets/doc-style.css
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/assets/doc-style.css
@@ -1,0 +1,162 @@
+/*
+ * Hibernate Mapping Documentation Style Sheet
+ */
+
+body
+{
+    margin: 0.5em;
+    background: white;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 10pt;
+}
+
+a
+{
+    color: #003399;
+}
+
+a:active
+{
+    color: #003399;
+}
+
+a:visited
+{
+    color: #888888;
+}
+
+p, ul, hr
+{
+    margin: 0.5em 0;
+}
+* html hr /* ie6 */
+{
+    margin: 0;
+}
+
+h1
+{
+    text-align: center;
+}
+
+table
+{
+    margin: 0.5em 0;
+    width: 100%;
+    border-collapse: collapse;
+}
+* html table /* ie6 only */
+{
+    margin: 1em 0;
+}
+
+th, td
+{
+    border: solid 1px #CCCCCC;
+    padding: 3px;
+}
+
+th
+{
+    background: #F4F4F4;
+    text-align: left;
+}
+
+td a
+{
+    font-weight: bold;
+}
+
+hr
+{
+    border: none;
+    border-top: 1px solid #CCCCCC;
+}
+* html hr /* ie6 only */
+{
+    height: 1px;
+}
+
+.MainTableHeading
+{
+    font-size: 20px;
+    font-weight: bold;
+}
+
+p.MainTableHeading
+{
+    background: #F4F4F4;
+    border: solid 1px #CCCCCC;
+    padding: 3px;
+}
+
+.List p
+{
+    margin: 0 0 10px 0;
+}
+
+.ListTitleFont
+{
+    font-size: large;
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+/* header */
+
+#logo
+{
+    float: right;
+    margin-bottom: 0.5em;
+}
+* html #logo /* ie6 */
+{
+    margin-bottom: 0;
+}
+
+#logo img
+{
+    display: block;
+    border: none;
+}
+
+#header ul
+{
+    list-style: none;
+    background: #F4F4F4;
+    padding: 4px;
+    margin: 0;
+}
+
+#header li
+{
+    display: inline;
+    margin-right: 3px;
+    padding: 0 3px;
+}
+
+#header li.selected
+{
+    background: silver;
+    color: white;
+    font-weight: bold;
+}
+
+#header a
+{
+    color: black;
+    font-weight: bold;
+}
+
+#header hr
+{
+    clear: right;
+}
+
+/* query sql*/
+
+td.QuerySql
+{
+    white-space: pre;
+}
+

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/assets/doc-style.css
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/assets/doc-style.css
@@ -160,3 +160,9 @@ td.QuerySql
     white-space: pre;
 }
 
+
+p.QueryComment
+{
+    white-space: pre-line;
+}
+

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/index.flt
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/index.flt
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
+
+<html>
+<head>
+    <title>Hibernate Mappings - Query Information</title>
+    <link rel="stylesheet" type="text/css" href="assets/doc-style.css" title="Style"/>
+</head>
+
+<frameset cols="20%,80%">
+    <frameset>
+        <frame src="allqueries.html" name="entitiesFrame" title="All Queries"/>
+    </frameset>
+    <frame src="queries-summary.html" name="generalFrame" title="Queries descriptions" scrolling="yes"/>
+    <noframes>
+        <body>
+        <h2>Frame Alert</h2>
+        <p>This document is designed to be viewed using the frames feature. If you see this message, you are using a non-frame-capable web client.</p>
+        </body>
+    </noframes>
+</frameset>
+
+</html>

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/queries-summary.flt
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/queries-summary.flt
@@ -37,7 +37,7 @@
     <h2 id="column_detail_CODE">Query ${q.name}</h2>
 
     <#if q.comment??>
-        <p>${q.comment}</p>
+        <p class="QueryComment">${q.comment}</p>
     </#if>
 
     <table>

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/queries-summary.flt
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/queries-summary.flt
@@ -1,0 +1,97 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+<head>
+    <title>Hibernate Mappings - Queries Info</title>
+    <link rel="stylesheet" type="text/css" href="assets/doc-style.css" title="Style"/>
+</head>
+<body>
+
+<div id="header">
+
+    <div id="logo">
+        <a href="http://www.hibernate.org/" target="_blank">
+            <img src="assets/hibernate_logo.gif" alt="Hibernate"/>
+        </a>
+    </div>
+
+    <ul>
+        <li><a href="../tables/index.html" target="_top">Tables</a></li>
+        <li><a href="../entities/index.html" target="_top">Entities</a></li>
+        <li class="selected">Queries</li>
+    </ul>
+    <hr/>
+
+</div>
+
+<h4>All queries</h4>
+
+
+<#list queries as q>
+
+    <br/><br/>
+    <hr></hr>
+
+    <a name="${q.name}"></a>
+    <h2 id="column_detail_CODE">Query ${q.name}</h2>
+
+    <#if q.comment??>
+        <p>${q.comment}</p>
+    </#if>
+
+    <table>
+        <thead>
+            <tr>
+                <th class="MainTableHeading">
+                    SQL query
+                </th>
+                <th class="MainTableHeading">
+                    HQL query
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="QuerySql"><#if q.sql??><#list q.sql as value>${value};</#list></#if></td>
+                <td class="QuerySql"><#if q.hql??>${q.hql}</#if></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <#if q.params??>
+        <table>
+            <thead>
+                <tr>
+                    <th class="MainTableHeading" colspan="4">
+                        Parameters
+                    </th>
+                </tr>
+                <tr>
+                    <th style="width: 14%">
+                        Name
+                    </th>
+                    <th style="width: 14%">
+                        Type
+                    </th>
+                    <th style="width: 72%">
+                        Description
+                    </th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <#list q.params?keys as name>
+                    <tr>
+                        <td>${name}</td>
+                        <td>${q.params[name]}</td>
+                        <td>&nbsp;</td>
+                    </tr>
+                </#list>
+            </tbody>
+        </table>
+    </#if>
+</#list>
+
+</body>
+</html>

--- a/src/main/resources/org/hibernate/tool/hbm2doc/queries/query.flt
+++ b/src/main/resources/org/hibernate/tool/hbm2doc/queries/query.flt
@@ -1,0 +1,361 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+<head>
+    <title>Hibernate Mappings - Entity Info</title>
+    <link rel="stylesheet" type="text/css" href="assets/doc-style.css" title="Style"/>
+</head>
+<body>
+
+<div id="header">
+
+    <div id="logo">
+        <a href="http://www.hibernate.org/" target="_blank">
+            <img src="assets/hibernate_logo.gif" alt="Hibernate"/>
+        </a>
+    </div>
+
+    <ul>
+        <li><a href="../tables/index.html" target="_top">Tables</a></li>
+        <li><a href="../entities/index.html" target="_top">Entities</a></li>
+    </ul>
+    <hr/>
+
+</div>
+
+<h2>Query ${query.name}</h2>
+
+<hr/>
+
+<table id="identifier_summary">
+    <thead>
+    <tr>
+        <th class="MainTableHeading" colspan="4">
+            Identifier Summary
+        </th>
+    </tr>
+    <tr>
+        <th style="width: 14%">
+            Name
+        </th>
+        <th style="width: 14%">
+            Column
+        </th>
+        <th style="width: 14%">
+            Type
+        </th>
+        <th style="width: 58%">
+            Description
+        </th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <tr>
+        <td>
+            <a href="#identifier_detail_id">
+                id
+            </a>
+        </td>
+        <td>
+            Column
+        </td>
+        <td>
+            Integer
+        </td>
+        <td>
+            &nbsp;
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<table id="property_summary">
+    <thead>
+    <tr>
+        <th class="MainTableHeading" colspan="5">
+            Property Summary
+        </th>
+    </tr>
+    <tr>
+        <th style="width: 14%">
+            Name
+        </th>
+        <th style="width: 14%">
+            Column
+        </th>
+        <th style="width: 14%">
+            Access
+        </th>
+        <th style="width: 14%">
+            Type
+        </th>
+        <th style="width: 44%">
+            Description
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_denormalizedBatch">
+                denormalizedBatch
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                BATCH_FK
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            DenormalizedBatchImpl
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_isInherited">
+                isInherited
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                IS_INHERITED
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            Boolean
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_numericalValue">
+                numericalValue
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                NUMERICAL_VALUE
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            Float
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_parameter">
+                parameter
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                PARAMETER_FK
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            ParameterImpl
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_pmfm">
+                pmfm
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                PMFM_FK
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            PmfmImpl
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_qualitativeValue">
+                qualitativeValue
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                QUALITATIVE_VALUE_FK
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            QualitativeValueImpl
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_rankOrder">
+                rankOrder
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                RANK_ORDER
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            Integer
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_remoteId">
+                remoteId
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                REMOTE_ID
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            Integer
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td rowspan="1">
+            <a href="#property_detail_unit">
+                unit
+            </a>
+        </td>
+
+        <td>
+            <a href="#property_summary">
+                UNIT_FK
+            </a>
+        </td>
+
+        <td rowspan="1">
+            property (<a href="#property_summary">get</a> / <a href="#property_summary">set</a>)
+        </td>
+
+        <td rowspan="1">
+            UnitImpl
+        </td>
+
+        <td rowspan="1">
+            &nbsp;
+        </td>
+    </tr>
+
+    </tbody>
+</table>
+
+
+<p id="identifier_detail" class="MainTableHeading">
+    Identifier Detail
+</p>
+<h3 id="identifier_detail_id">id</h3>
+
+
+<p id="property_detail" class="MainTableHeading">
+    Property Detail
+</p>
+<h3 id="property_detail_rankOrder">rankOrder</h3>
+<hr/>
+<h3 id="property_detail_isInherited">isInherited</h3>
+<hr/>
+<h3 id="property_detail_numericalValue">numericalValue</h3>
+<hr/>
+<h3 id="property_detail_remoteId">remoteId</h3>
+<hr/>
+<h3 id="property_detail_pmfm">pmfm</h3>
+<hr/>
+<h3 id="property_detail_unit">unit</h3>
+<hr/>
+<h3 id="property_detail_denormalizedBatch">denormalizedBatch</h3>
+<hr/>
+<h3 id="property_detail_qualitativeValue">qualitativeValue</h3>
+<hr/>
+<h3 id="property_detail_parameter">parameter</h3>
+<hr/>
+
+</body>
+</html>


### PR DESCRIPTION
This allow pull-request allow you to get a SQL file with all hibernate queries.

Each query is well documented, so you could send this file to a database manager, to debug or follows queries. The link between the SQL qeury and Hibernate code is easy to keep.

in another pull request, i will try to add a site report with all queries (like hbm2doc does).
